### PR TITLE
Add copy-from and extend to item groups

### DIFF
--- a/Learn to Fly/learn_to_fly/itemgroups/books.json
+++ b/Learn to Fly/learn_to_fly/itemgroups/books.json
@@ -1,29 +1,24 @@
 [
-  {
-    "type": "item_group",
-    "id": "lab_bookshelves",
-	"subtype": "distribution",
-	"entries": [
-		{ "item": "book_pilot_heli", "prob": 3 },
-		{ "item": "book_repair_aircraft", "prob": 2 }
-	]
-  },
-  {
-    "type": "item_group",
-    "id": "book_military",
-	"subtype": "distribution",
-	"entries": [
-		{ "item": "book_pilot_heli", "prob": 2 },
-		{ "item": "book_repair_aircraft", "prob": 3 }
-	]
-  },
-  {
-    "type": "item_group",
-    "id": "hardware_books",
-	"subtype": "distribution",
-	"entries": [
-		{ "item": "book_pilot_heli", "prob": 1 },
-		{ "item": "book_repair_aircraft", "prob": 1 }
-	]
-  }
-]
+	{
+	  "type": "item_group",
+	  "id": "lab_bookshelves",
+	  "copy-from": "lab_bookshelves",
+	  "subtype": "distribution",
+	  "extend": { "entries": [ { "item": "book_pilot_heli", "prob": 3 }, { "item": "book_repair_aircraft", "prob": 2 } ] }
+	},
+	{
+	  "type": "item_group",
+	  "id": "book_military",
+	  "copy-from": "book_military",
+	  "subtype": "distribution",
+	  "extend": { "entries": [ { "item": "book_pilot_heli", "prob": 2 }, { "item": "book_repair_aircraft", "prob": 3 } ] }
+	},
+	{
+	  "type": "item_group",
+	  "id": "hardware_books",
+	  "copy-from": "hardware_books",
+	  "subtype": "distribution",
+	  "extend": { "entries": [ { "item": "book_pilot_heli", "prob": 1 }, { "item": "book_repair_aircraft", "prob": 1 } ] }
+	}
+  ]
+  


### PR DESCRIPTION
By default, just adding the group would replace the vanilla item groups. If you `copy-from` then `extend` that copied group with your entries, it'll work as intended! 

Great mod! Idk if you've talked to senior devs about it, but it seems like it could be mainlined to me.

_Side-note: In keeping with some of the super-technical Army manuals already in the game, "AFM" could theoretically be renamed to "FM 3-04.240 Instrument Flight for Army Aviators" ([link](https://www.globalsecurity.org/military/library/policy/army/fm/3-04-240/fm3-04-240.pdf)). Also "OD 0610 Principles of Automotive Engines" ([link](https://www.militarynewbie.com/wp-content/uploads/2013/11/US-Army-mechanic-course-Principles-of-Automotive-Engines-OD0610.pdf)) maybe the other? Idk, just an idea!_